### PR TITLE
feat: YouTube Music Desteği ve Evrensel Senkronizasyon Radarı

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,8 +5,7 @@
   "description": "YouTube videolarını arkadaşlarınla senkronize izle.",
   "permissions": ["activeTab", "storage"],
   "action": {
-      "default_popup": "popup.html",
-      "default_js": ["popup.js"] 
+      "default_popup": "popup.html"
   },
   "background": {
     "service_worker": "background.js"


### PR DESCRIPTION
## feat: YouTube Music Desteği ve Evrensel Senkronizasyon Radarı

### 🎯 Problem
Eklentimiz yeni şarkı geçişlerini anlamak için sadece klasik YouTube'a özel olan `yt-navigate-finish` kapı zilini (event) dinliyordu. YouTube Music bu sinyali kullanmadığı için, YouTube Music üzerinde şarkı değiştiğinde eklenti bunu algılamıyor ve senkronizasyon kopuyordu.

### 🛠️ Çözüm ve Teknik Detaylar
* **Özel Dinleyici Temizlendi:** Sadece YouTube'da çalışan hantal event listener koddan tamamen çıkartıldı.
* **Evrensel Radar (`content.js`):** Yerine, tarayıcının adres çubuğunu (URL) saniyede iki kez kontrol eden evrensel bir radar mekanizması (`checkPageStatus` içine) eklendi.
* Artık adres çubuğunda link değiştiği an (ister YouTube, ister YouTube Music olsun), sistem bunu anında yakalayıp odaya `URL_CHANGE` sinyali fırlatıyor ve oynatma listesi parametrelerini başarıyla temizliyor.

### 🧪 Nasıl Test Edilir?
- [ ] YouTube Music'i açın ve bir odaya bağlanın.
- [ ] Başka bir sekmeden/bilgisayardan aynı odaya girin.
- [ ] Ana ekranda yeni bir şarkıya tıklayın (URL'nin değişmesini sağlayın).
- [ ] Diğer kullanıcının ekranında da şarkının anında değiştiğini ve senkronizasyonun kusursuz çalıştığını teyit edin.