### PR TITLE
background.js

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,7 +1,38 @@
-// Sahneden (content.js) gelen "Işığı Yak" veya "Söndür" emirlerini dinle
+// --- BADGE MESAJLARI ---
+// Content.js'ten gelen badge güncelleme isteklerini uygular.
 chrome.runtime.onMessage.addListener((message, sender) => {
     if (message.type === "SET_BADGE" && sender.tab) {
         chrome.action.setBadgeText({ text: message.text, tabId: sender.tab.id });
         chrome.action.setBadgeBackgroundColor({ color: message.color, tabId: sender.tab.id });
     }
+});
+
+// --- TAB KAPANMA TEMİZLİĞİ ---
+// Kullanıcı aktif JamRoom tab'ını kapattığında LEAVE_ROOM mesajı gönderilemez
+// çünkü content.js zaten yok edilmiştir. Bu listener tab kapanmadan ÖNCE
+// tetiklenerek storage ve badge'i temizler.
+//
+// Neden background.js? Content script'in ömrü tab ile sona erer;
+// tab kapanma olayını güvenilir şekilde yakalayabilecek tek yer
+// her zaman canlı olan service worker'dır.
+chrome.tabs.onRemoved.addListener((tabId) => {
+    chrome.storage.local.get(['activeTabId'], (result) => {
+        // Kapanan tab, JamRoom'un aktif olduğu tab değilse işlem yapma.
+        if (result.activeTabId !== tabId) return;
+
+        // Storage'ı temizle: oda oturumu artık geçersiz.
+        // roomUserCount ve roomUserList de temizlenir;
+        // popup yeniden açılınca "Not in an active room." gösterilir.
+        chrome.storage.local.remove([
+            'savedRoomId',
+            'activeTabId',
+            'roomUserCount',
+            'roomUserList',
+        ]);
+
+        // Badge zaten tab kapandığı için görünmez olur;
+        // yine de explicit temizlik yapıyoruz — tab restore edilirse
+        // eski "ON" badge'i kalmasın.
+        chrome.action.setBadgeText({ text: "", tabId });
+    });
 });

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -44,9 +44,10 @@ document.getElementById('joinBtn').addEventListener('click', () => {
       return; // İşlemi durdur
     }
 
-    // Oda adını Chrome local storage'a kaydediyoruz
-    // Bu sayede popup kapanıp açılsa bile oda bilgisi hatırlanır
-    chrome.storage.local.set({ savedRoomId: roomId }, () => {
+    // Oda adı ve aktif tab ID'sini storage'a kaydediyoruz.
+    // activeTabId: background.js'in tab kapanma olayında hangi tab'ı
+    // izleyeceğini bilmesi için gerekli — tab kapanınca otomatik cleanup yapar.
+    chrome.storage.local.set({ savedRoomId: roomId, activeTabId: currentTab.id }, () => {
 
       // Content script'e JOIN komutu gönderiyoruz
       sendMessageToContent("JOIN_NEW_ROOM", roomId);
@@ -77,8 +78,8 @@ document.getElementById('leaveBtn').addEventListener('click', () => {
     // Content script'e odadan çık komutu gönder
     sendMessageToContent("LEAVE_ROOM", null);
 
-    // Local storage'dan kayıtlı oda ve kullanıcı sayısını temizle
-    chrome.storage.local.remove(['savedRoomId', 'roomUserCount']);
+    // Local storage'dan kayıtlı oda, aktif tab ve kullanıcı bilgilerini temizle
+    chrome.storage.local.remove(['savedRoomId', 'activeTabId', 'roomUserCount']);
 
     // UI durumunu sıfırla
     setStatus("Not in an active room.");


### PR DESCRIPTION
chrome.tabs.onRemoved listener eklendi. Tab kapanınca activeTabId ile karşılaştırma yapılır; eşleşirse savedRoomId, activeTabId, roomUserCount, roomUserList storage'dan temizlenir. Popup bir sonraki açılışında "Not in an active room." gösterir. popup.js:
JOIN sırasında savedRoomId ile birlikte activeTabId: currentTab.id de storage'a yazılıyor — background.js'in hangi tab'ı izleyeceğini bilmesi için gereken bilgi. LEAVE butonunda activeTabId de remove listesine eklendi — manuel çıkışta da state tutarlı kalıyor.

fixes#37